### PR TITLE
Add time-shifted object states

### DIFF
--- a/main.js
+++ b/main.js
@@ -60,6 +60,28 @@ class TestScene extends Phaser.Scene {
 
     this.cursors = this.input.keyboard.createCursorKeys();
 
+    this.shiftKey = this.input.keyboard.addKey('T');
+
+    this.timeObjects = this.physics.add.group();
+    const block = this.physics.add.image(400, 300, 'ground');
+    block.setData('states', {
+      past: {
+        x: 400,
+        y: 300,
+        tint: 0x00ffff,
+        immovable: true,
+        gravity: false
+      },
+      future: {
+        tint: 0xff0000,
+        immovable: false,
+        gravity: true
+      }
+    });
+    this.applyState(block, 'past');
+    this.timeObjects.add(block);
+    this.physics.add.collider(this.player, block);
+
     this.cameras.main.setBounds(0, 0, 1600, 600);
     this.physics.world.setBounds(0, 0, 1600, 600);
     this.cameras.main.startFollow(this.player, true, 0.08, 0.08);
@@ -85,6 +107,18 @@ class TestScene extends Phaser.Scene {
     });
   }
 
+  applyState(obj, state) {
+    const data = obj.getData('states')[state];
+    obj.setTint(data.tint);
+    obj.setImmovable(data.immovable);
+    obj.body.setAllowGravity(data.gravity);
+    if (state === 'past') {
+      obj.setPosition(data.x, data.y);
+      obj.body.setVelocity(0, 0);
+    }
+    obj.setData('activeState', state);
+  }
+
   update() {
     const onGround = this.player.body.blocked.down;
     this.player.setDragX(onGround ? 800 : 50);
@@ -102,6 +136,14 @@ class TestScene extends Phaser.Scene {
 
     if (this.cursors.up.isDown && onGround) {
       this.player.setVelocityY(-400);
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.shiftKey)) {
+      this.timeObjects.children.iterate(obj => {
+        const current = obj.getData('activeState');
+        const next = current === 'past' ? 'future' : 'past';
+        this.applyState(obj, next);
+      });
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -10,13 +10,15 @@ combat to rebuild the original timeline.
 1. Clone this repository.
 2. Open `index.html` in a modern browser or serve it with a local static
    server.
-3. Use the arrow keys to move and jump.
+3. Use the arrow keys to move and jump. Press `T` to shift objects through
+   time.
 
 ## Features
 
 - Side-view movement with jumping and collision.
 - Layered backgrounds with parallax depth.
 - Basic physics including gravity, friction, and camera follow.
+- Time-shift objects between past and future states with the `T` key.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Introduce time-shift objects with past and future states stored in metadata
- Allow players to toggle object states using the `T` key, updating physics accordingly
- Document time-shift controls in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68956168e3e4832c864b59dcaa19b03c