### PR TITLE
Generate script-based text platforms

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ class TestScene extends Phaser.Scene {
   }
 
   preload() {
+    this.load.text('script', 'script.txt');
     this.load.image(
       'bg-far',
       'https://labs.phaser.io/assets/skies/space3.png'
@@ -37,18 +38,45 @@ class TestScene extends Phaser.Scene {
       .setScrollFactor(0.3)
       .setDisplaySize(1600, 600);
 
-    const platforms = this.physics.add.staticGroup();
-    platforms
+    const ground = this.physics.add.staticGroup();
+    ground
       .create(400, 568, 'ground')
       .setScale(2)
       .refreshBody();
-    platforms
+    ground
       .create(1200, 568, 'ground')
       .setScale(2)
       .refreshBody();
-    platforms.create(600, 400, 'ground');
-    platforms.create(50, 250, 'ground');
-    platforms.create(750, 220, 'ground');
+
+    const script = this.cache.text.get('script');
+    const lines = script
+      ? script.trim().split('\n')
+      : [
+          'Default platform 1',
+          'Default platform 2',
+          'Default platform 3'
+        ];
+
+    const textPlatforms = this.physics.add.group({
+      allowGravity: false,
+      immovable: true
+    });
+    let x = 200;
+    lines.forEach((line, i) => {
+      const y = 400 - i * 80;
+      const text = this.add
+        .text(x, y, line, {
+          fontSize: '20px',
+          color: '#fff',
+          backgroundColor: '#000'
+        })
+        .setPadding(4);
+      this.physics.add.existing(text);
+      text.body.setAllowGravity(false);
+      text.body.setImmovable(true);
+      textPlatforms.add(text);
+      x += text.width + 50;
+    });
 
     this.player = this.physics.add.sprite(100, 450, 'dude');
     this.player.setBounce(0.1);
@@ -56,12 +84,14 @@ class TestScene extends Phaser.Scene {
     this.player.setDragX(1000);
     this.player.setMaxVelocity(300, 500);
 
-    this.physics.add.collider(this.player, platforms);
+    this.physics.add.collider(this.player, ground);
+    this.physics.add.collider(this.player, textPlatforms);
 
     this.cursors = this.input.keyboard.createCursorKeys();
 
-    this.cameras.main.setBounds(0, 0, 1600, 600);
-    this.physics.world.setBounds(0, 0, 1600, 600);
+    const worldWidth = Math.max(1600, x + 200);
+    this.cameras.main.setBounds(0, 0, worldWidth, 600);
+    this.physics.world.setBounds(0, 0, worldWidth, 600);
     this.cameras.main.startFollow(this.player, true, 0.08, 0.08);
 
     this.anims.create({

--- a/readme.md
+++ b/readme.md
@@ -17,12 +17,14 @@ media.
 - Layered backgrounds with parallax depth.
 - Basic physics including gravity, friction, and camera follow.
 - Simple room layout for movement testing.
+- Script-driven platforms generated from `script.txt` lines.
 
 ## Project Structure
 
 - `index.html` – entry point for the game.
 - `main.js` – main game logic and prototype scene.
 - `config.js` – configuration settings.
+- `script.txt` – lines used to build text platforms.
 
 ## Contributing
 

--- a/script.txt
+++ b/script.txt
@@ -1,0 +1,4 @@
+Once upon a time
+text became a bridge
+words shaped the path
+and syntax led the way


### PR DESCRIPTION
## Summary
- build collidable text platforms from lines in `script.txt`
- adjust world size to fit generated platforms and default to placeholder lines
- document script-driven platforms in README

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Video-Game/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689564f5e2b8832cacf7b8e399debdca