### PR TITLE
Add popsicle enemy with flavor-based combat

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 import { config } from './config.js';
+import { PopsicleEnemy } from './popsicle.js';
 
 class TestScene extends Phaser.Scene {
   constructor() {
@@ -24,6 +25,21 @@ class TestScene extends Phaser.Scene {
       'https://labs.phaser.io/assets/sprites/dude.png',
       { frameWidth: 32, frameHeight: 48 }
     );
+
+    const g = this.add.graphics();
+    g.fillStyle(0xffffff, 1);
+    g.fillRect(8, 32, 4, 8);
+    g.fillStyle(0xff0000, 1);
+    g.fillRect(0, 0, 20, 32);
+    g.generateTexture('popsicle', 20, 40);
+    g.clear();
+    g.fillStyle(0xffffff, 1);
+    g.fillCircle(4, 4, 4);
+    g.generateTexture('bullet', 8, 8);
+    g.clear();
+    g.fillCircle(2, 2, 2);
+    g.generateTexture('drip', 4, 4);
+    g.destroy();
   }
 
   create() {
@@ -38,12 +54,12 @@ class TestScene extends Phaser.Scene {
       .setScrollFactor(0.3)
       .setDisplaySize(1600, 600);
 
-    const ground = this.physics.add.staticGroup();
-    ground
+    this.ground = this.physics.add.staticGroup();
+    this.ground
       .create(400, 568, 'ground')
       .setScale(2)
       .refreshBody();
-    ground
+    this.ground
       .create(1200, 568, 'ground')
       .setScale(2)
       .refreshBody();
@@ -84,10 +100,12 @@ class TestScene extends Phaser.Scene {
     this.player.setDragX(1000);
     this.player.setMaxVelocity(300, 500);
 
-    this.physics.add.collider(this.player, ground);
+    this.physics.add.collider(this.player, this.ground);
     this.physics.add.collider(this.player, textPlatforms);
 
     this.cursors = this.input.keyboard.createCursorKeys();
+    this.fireKey = this.input.keyboard.addKey('Z');
+    this.iceKey = this.input.keyboard.addKey('X');
 
     const worldWidth = Math.max(1600, x + 200);
     this.cameras.main.setBounds(0, 0, worldWidth, 600);
@@ -119,6 +137,37 @@ class TestScene extends Phaser.Scene {
       frameRate: 10,
       repeat: -1
     });
+
+    this.bullets = this.physics.add.group();
+    this.drops = this.physics.add.group();
+    this.popsicles = this.physics.add.group({
+      classType: PopsicleEnemy,
+      runChildUpdate: true
+    });
+    this.popsicles.add(new PopsicleEnemy(this, 600, 450, 'cherry'));
+    this.popsicles.add(new PopsicleEnemy(this, 800, 450, 'lime'));
+    this.physics.add.collider(this.popsicles, this.ground);
+    this.physics.add.collider(this.drops, this.ground, drop => drop.destroy());
+    this.physics.add.overlap(
+      this.bullets,
+      this.popsicles,
+      (popsicle, bullet) => {
+        popsicle.hit(bullet.flavor);
+        bullet.destroy();
+      }
+    );
+    this.physics.add.overlap(
+      this.player,
+      this.drops,
+      (player, drop) => {
+        drop.destroy();
+        player.setTint(0x9999ff);
+        this.time.addEvent({
+          delay: 500,
+          callback: () => player.clearTint()
+        });
+      }
+    );
   }
 
   update() {
@@ -128,17 +177,44 @@ class TestScene extends Phaser.Scene {
     if (this.cursors.left.isDown) {
       this.player.setAccelerationX(-600);
       this.player.anims.play('left', true);
+      this.player.lastDir = -1;
     } else if (this.cursors.right.isDown) {
       this.player.setAccelerationX(600);
       this.player.anims.play('right', true);
+      this.player.lastDir = 1;
     } else {
       this.player.setAccelerationX(0);
       this.player.anims.play('turn', true);
     }
 
+    if (Phaser.Input.Keyboard.JustDown(this.fireKey)) {
+      this.fireBullet('fire');
+    }
+    if (Phaser.Input.Keyboard.JustDown(this.iceKey)) {
+      this.fireBullet('ice');
+    }
+
     if (this.cursors.up.isDown && onGround) {
       this.player.setVelocityY(-400);
     }
+  }
+
+  fireBullet(flavor) {
+    const bullet = this.physics.add.image(
+      this.player.x,
+      this.player.y,
+      'bullet'
+    );
+    bullet.setTint(flavor === 'fire' ? 0xffa500 : 0x00ffff);
+    bullet.flavor = flavor;
+    const dir = this.player.lastDir || 1;
+    bullet.setVelocityX(400 * dir);
+    bullet.setGravityY(-this.physics.world.gravity.y);
+    this.time.addEvent({
+      delay: 2000,
+      callback: () => bullet.destroy()
+    });
+    this.bullets.add(bullet);
   }
 }
 

--- a/popsicle.js
+++ b/popsicle.js
@@ -1,0 +1,102 @@
+export class PopsicleEnemy extends Phaser.Physics.Arcade.Sprite {
+  constructor(scene, x, y, flavor) {
+    super(scene, x, y, 'popsicle');
+    scene.add.existing(this);
+    scene.physics.add.existing(this);
+    this.flavor = flavor;
+    this.state = 'solid';
+    this.setTint(PopsicleEnemy.FLAVOR_TINTS[flavor] || 0xffffff);
+    this.setCollideWorldBounds(true);
+    this.setBounce(0.2);
+    this.dripEvent = scene.time.addEvent({
+      delay: 2000,
+      callback: this.drip,
+      callbackScope: this,
+      loop: true
+    });
+  }
+
+  static FLAVOR_TINTS = {
+    cherry: 0xff0000,
+    lime: 0x00ff00,
+    blueberry: 0x0000ff
+  };
+
+  static FLAVOR_WEAKNESS = {
+    cherry: 'fire',
+    lime: 'ice',
+    blueberry: 'fire'
+  };
+
+  drip() {
+    if (this.state !== 'solid') return;
+    const drop = this.scene.physics.add.image(
+      this.x,
+      this.y + 20,
+      'drip'
+    );
+    drop.setTint(this.tintTopLeft);
+    drop.setVelocityY(200);
+    drop.setGravityY(0);
+    this.scene.time.addEvent({
+      delay: 4000,
+      callback: () => drop.destroy()
+    });
+    this.scene.drops.add(drop);
+  }
+
+  hit(flavor) {
+    if (this.state !== 'solid') return;
+    if (PopsicleEnemy.FLAVOR_WEAKNESS[this.flavor] === flavor) {
+      this.melt();
+    } else {
+      this.freeze();
+    }
+  }
+
+  melt() {
+    this.state = 'melted';
+    this.disableBody(true, false);
+    const particles = this.scene.add.particles('drip');
+    particles.setTint(this.tintTopLeft);
+    particles.createEmitter({
+      x: this.x,
+      y: this.y,
+      speed: { min: -50, max: 50 },
+      lifespan: 800,
+      quantity: 20
+    });
+    this.scene.time.addEvent({
+      delay: 3000,
+      callback: this.reform,
+      callbackScope: this
+    });
+  }
+
+  freeze() {
+    this.state = 'frozen';
+    this.setTint(0x99ccff);
+    this.setVelocity(0, 0);
+    this.scene.time.addEvent({
+      delay: 2000,
+      callback: () => {
+        this.state = 'solid';
+        this.setTint(
+          PopsicleEnemy.FLAVOR_TINTS[this.flavor] || 0xffffff
+        );
+      }
+    });
+  }
+
+  reform() {
+    this.enableBody(true, this.x, this.y, true, true);
+    this.state = 'solid';
+    this.setScale(0);
+    this.scene.tweens.add({
+      targets: this,
+      scaleX: 1,
+      scaleY: 1,
+      duration: 800
+    });
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ media.
 2. Open `index.html` in a modern browser or serve it with a local static
    server.
 3. Use the arrow keys to move and jump.
+4. Press `Z` for fire shots and `X` for ice shots.
 
 ## Features
 
@@ -18,6 +19,8 @@ media.
 - Basic physics including gravity, friction, and camera follow.
 - Simple room layout for movement testing.
 - Script-driven platforms generated from `script.txt` lines.
+- Popsicle enemies with melting, freezing, and reforming states.
+- Flavor-based weaknesses and dripping attacks with particle effects.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Create popsicle enemy class with dripping attack, melting and reforming
- Wire popsicles, bullets, and flavor-based weaknesses into the scene
- Document new controls and enemy behavior in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895678e2108832c889d95d934928eae