### PR TITLE
Add video format modes with visual and physics changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,17 @@ media.
 - Script-driven platforms generated from `script.txt` lines.
 - Popsicle enemies with melting, freezing, and reforming states.
 - Flavor-based weaknesses and dripping attacks with particle effects.
+- Video format modes (Betamax, 8mm, MPEG2, MiniDV) altering visuals and
+  physics; press number keys 1–4 to switch.
+
+## Format Modes
+
+Switch between media styles for different looks and physics tweaks:
+
+1 - Betamax: sepia filter with heavier gravity.
+2 - 8mm: grainy monochrome and slower movement.
+3 - MPEG2: vibrant colors with baseline physics.
+4 - MiniDV: bright, high-contrast visuals and lighter gravity.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- add Betamax, 8mm, MPEG2, and MiniDV modes with unique filters, tints, and physics parameters
- wire keys 1–4 to switch modes and instantly update visuals and movement
- document new format modes and controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689568dde474832caa6bbd81ba89f545