### PR TITLE
Expand popsicle lifecycle and Alden Institute setting

### DIFF
--- a/popsicle.js
+++ b/popsicle.js
@@ -55,7 +55,7 @@ export class PopsicleEnemy extends Phaser.Physics.Arcade.Sprite {
   }
 
   melt() {
-    this.state = 'melted';
+    this.state = 'collection';
     this.disableBody(true, false);
     const particles = this.scene.add.particles('drip');
     particles.setTint(this.tintTopLeft);
@@ -67,10 +67,68 @@ export class PopsicleEnemy extends Phaser.Physics.Arcade.Sprite {
       quantity: 20
     });
     this.scene.time.addEvent({
-      delay: 3000,
-      callback: this.reform,
+      delay: 600,
+      callback: this.crystallize,
       callbackScope: this
     });
+  }
+
+  crystallize() {
+    this.state = 'crystallizing';
+    this.scene.time.addEvent({
+      delay: 600,
+      callback: this.scaffold,
+      callbackScope: this
+    });
+  }
+
+  scaffold() {
+    this.state = 'scaffold';
+    this.scene.time.addEvent({
+      delay: 600,
+      callback: this.reassemble,
+      callbackScope: this
+    });
+  }
+
+  reassemble() {
+    this.state = 'reassembly';
+    this.scene.time.addEvent({
+      delay: 600,
+      callback: this.calibrate,
+      callbackScope: this
+    });
+  }
+
+  calibrate() {
+    this.state = 'calibration';
+    this.scene.time.addEvent({
+      delay: 600,
+      callback: this.release,
+      callbackScope: this
+    });
+  }
+
+  release() {
+    if (Math.random() < 0.2) {
+      this.recycle();
+      return;
+    }
+    this.enableBody(true, this.x, this.y, true, true);
+    this.state = 'solid';
+    this.setScale(0);
+    this.scene.tweens.add({
+      targets: this,
+      scaleX: 1,
+      scaleY: 1,
+      duration: 800
+    });
+  }
+
+  recycle() {
+    this.state = 'recycled';
+    this.dripEvent.remove(false);
+    this.destroy();
   }
 
   freeze() {
@@ -85,18 +143,6 @@ export class PopsicleEnemy extends Phaser.Physics.Arcade.Sprite {
           PopsicleEnemy.FLAVOR_TINTS[this.flavor] || 0xffffff
         );
       }
-    });
-  }
-
-  reform() {
-    this.enableBody(true, this.x, this.y, true, true);
-    this.state = 'solid';
-    this.setScale(0);
-    this.scene.tweens.add({
-      targets: this,
-      scaleX: 1,
-      scaleY: 1,
-      duration: 800
     });
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,23 @@ A browser-based surrealist sci-fi platformer concept. Play as Juno, a junior
 archivist navigating a glitching research facility fragmented across time and
 media.
 
+## Setting
+
+The game takes place at the Alden Institute for Temporal Media and Experimental
+Archives, located at 3100 Alden Drive. The brutalist-meets-neofuturist complex
+features a spire that tracks the sun, retractable copper sunshades shaped like
+timecode symbols, and a countdown above the door that never reaches zero. The
+interior includes a lobby filled with looping LED murals, a basement archive of
+obsolete media formats, and edit bays named after dead philosophers.
+
+## Lab 32: Popsicle Reconstitution
+
+In Bay 3B, melted popsicles undergo a six-phase journey from slush to sentience
+inspired by the procedures of Lab 32. Samples are collected, crystallized,
+scaffolded onto memory-anchored sticks, refrozen with sonic nostalgia pulses,
+calibrated by mechanical tasters, then either archived or recycled into the
+Primordial Slush.
+
 ## Getting Started
 
 1. Clone this repository.
@@ -19,7 +36,7 @@ media.
 - Basic physics including gravity, friction, and camera follow.
 - Simple room layout for movement testing.
 - Script-driven platforms generated from `script.txt` lines.
-- Popsicle enemies with melting, freezing, and reforming states.
+- Popsicle enemies that progress through Lab 32's reconstitution phases.
 - Flavor-based weaknesses and dripping attacks with particle effects.
 - Video format modes (Betamax, 8mm, MPEG2, MiniDV) altering visuals and
   physics; press number keys 1–4 to switch.

--- a/script.txt
+++ b/script.txt
@@ -3,3 +3,8 @@ Search each frame for truth
 Align the splice points
 Restore the proper timeline
 Playback integrity depends on you
+The LED mural loops forgotten footage above the lobby
+Ozone and vinegar breathe from the basement vault
+Philosophers' names glow on edit bay consoles
+Crystals sing nineteen hertz in Bay 3B's lattice chamber
+Mechanical tasters sample memories at age nine point four


### PR DESCRIPTION
## Summary
- Add Lab 32–inspired reconstitution phases to popsicle enemies
- Detail Alden Institute setting and popsicle lab in README
- Enrich in-game script with building and lab imagery

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895768aad28832cbfeafd00dde0eabd