### PR TITLE
Add base enemy system with drone and turret types

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,8 @@ import { config } from './config.js';
 import { PopsicleEnemy } from './popsicle.js';
 import { CodecItem, CODEC_FUSIONS } from './codec.js';
 import { LevelManager } from './src/level/manager.js';
+import { DroneEnemy } from './src/enemies/drone.js';
+import { TurretEnemy } from './src/enemies/turret.js';
 
 function percentToTimecode(percent) {
   const totalFrames = Math.floor((percent / 100) * 60 * 24);
@@ -92,6 +94,14 @@ class TestScene extends Phaser.Scene {
     g.fillRect(0, 0, 16, 16);
     g.generateTexture('codec', 16, 16);
     g.clear();
+    g.fillStyle(0x00ff00, 1);
+    g.fillRect(0, 0, 20, 20);
+    g.generateTexture('drone', 20, 20);
+    g.clear();
+    g.fillStyle(0xff00ff, 1);
+    g.fillRect(0, 0, 20, 20);
+    g.generateTexture('turret', 20, 20);
+    g.clear();
     g.fillStyle(0x444444, 1);
     g.fillRect(0, 0, 40, 80);
     g.generateTexture('door', 40, 80);
@@ -175,6 +185,16 @@ class TestScene extends Phaser.Scene {
     });
     this.popsicles.add(new PopsicleEnemy(this, 600, 450, 'cherry'));
     this.popsicles.add(new PopsicleEnemy(this, 800, 450, 'lime'));
+    this.drones = this.physics.add.group({
+      classType: DroneEnemy,
+      runChildUpdate: true
+    });
+    this.drones.add(new DroneEnemy(this, 400, 300));
+    this.turrets = this.physics.add.group({
+      classType: TurretEnemy,
+      runChildUpdate: true
+    });
+    this.turrets.add(new TurretEnemy(this, 1000, 520));
     this.physics.add.collider(
       this.player,
       this.popsicles,
@@ -182,6 +202,24 @@ class TestScene extends Phaser.Scene {
     );
     this.physics.add.collider(
       this.popsicles,
+      this.levelManager.platforms
+    );
+    this.physics.add.collider(
+      this.player,
+      this.drones,
+      () => this.takeDamage(10)
+    );
+    this.physics.add.collider(
+      this.drones,
+      this.levelManager.platforms
+    );
+    this.physics.add.collider(
+      this.player,
+      this.turrets,
+      () => this.takeDamage(10)
+    );
+    this.physics.add.collider(
+      this.turrets,
       this.levelManager.platforms
     );
     this.physics.add.collider(
@@ -194,6 +232,22 @@ class TestScene extends Phaser.Scene {
       this.popsicles,
       (popsicle, bullet) => {
         popsicle.hit(bullet.flavor);
+        bullet.destroy();
+      }
+    );
+    this.physics.add.overlap(
+      this.bullets,
+      this.drones,
+      (drone, bullet) => {
+        drone.hit(bullet.flavor, this.currentMode);
+        bullet.destroy();
+      }
+    );
+    this.physics.add.overlap(
+      this.bullets,
+      this.turrets,
+      (turret, bullet) => {
+        turret.hit(bullet.flavor, this.currentMode);
         bullet.destroy();
       }
     );

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,8 @@ Primordial Slush.
 - Three interconnected rooms enable backtracking and hidden paths.
 - Popsicle enemies that progress through Lab 32's reconstitution phases.
 - Flavor-based weaknesses and dripping attacks with particle effects.
+- Drone and turret enemies using a shared base class with media mode or
+  bullet flavor weaknesses.
 - Video format modes (Betamax, 8mm, MPEG2, MiniDV) altering visuals and
   physics; press number keys 1–4 to switch.
 - Mode-specific abilities like block breaking or time slowing that
@@ -65,6 +67,7 @@ Switch between media styles for different looks and physics tweaks:
 - `config.js` – configuration settings.
 - `src/level/manager.js` – loads room data and handles transitions.
 - `src/level/rooms/` – JSON room definitions.
+- `src/enemies/` – base class and enemy types.
 
 ## Contributing
 

--- a/src/enemies/base.js
+++ b/src/enemies/base.js
@@ -1,0 +1,16 @@
+export class Enemy extends Phaser.Physics.Arcade.Sprite {
+  constructor(scene, x, y, texture) {
+    super(scene, x, y, texture);
+    scene.add.existing(this);
+    scene.physics.add.existing(this);
+    this.setCollideWorldBounds(true);
+  }
+
+  hit(flavor, mode) {
+    if (this.weaknessFlavor && flavor === this.weaknessFlavor) {
+      this.destroy();
+    } else if (this.weaknessMode && mode === this.weaknessMode) {
+      this.destroy();
+    }
+  }
+}

--- a/src/enemies/drone.js
+++ b/src/enemies/drone.js
@@ -1,0 +1,19 @@
+import { Enemy } from './base.js';
+
+export class DroneEnemy extends Enemy {
+  constructor(scene, x, y) {
+    super(scene, x, y, 'drone');
+    this.body.allowGravity = false;
+    this.speed = 100;
+    this.direction = 1;
+    this.weaknessFlavor = 'fire';
+  }
+
+  preUpdate(time, delta) {
+    super.preUpdate(time, delta);
+    this.setVelocityX(this.speed * this.direction);
+    if (this.body.blocked.left || this.body.blocked.right) {
+      this.direction *= -1;
+    }
+  }
+}

--- a/src/enemies/turret.js
+++ b/src/enemies/turret.js
@@ -1,0 +1,33 @@
+import { Enemy } from './base.js';
+
+export class TurretEnemy extends Enemy {
+  constructor(scene, x, y) {
+    super(scene, x, y, 'turret');
+    this.weaknessMode = '8mm';
+    this.fireEvent = scene.time.addEvent({
+      delay: 1500,
+      callback: this.fire,
+      callbackScope: this,
+      loop: true
+    });
+  }
+
+  fire() {
+    const bullet = this.scene.physics.add.image(this.x, this.y, 'bullet');
+    bullet.setTint(0xff0000);
+    bullet.setGravityY(-this.scene.physics.world.gravity.y);
+    this.scene.physics.moveToObject(bullet, this.scene.player, 200);
+    this.scene.hazards.add(bullet);
+    this.scene.time.addEvent({
+      delay: 3000,
+      callback: () => bullet.destroy()
+    });
+  }
+
+  destroy(fromScene) {
+    if (this.fireEvent) {
+      this.fireEvent.remove(false);
+    }
+    super.destroy(fromScene);
+  }
+}


### PR DESCRIPTION
## Summary
- create shared `Enemy` base class with flavor or mode weaknesses
- add `DroneEnemy` that patrols horizontally and `TurretEnemy` that fires at the player
- register drone and turret enemies in TestScene and document new enemies

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68957af4b938832c88edd8978e174de9