### PR TITLE
Add codec fusion puzzles with switches and elevators

### DIFF
--- a/codec.js
+++ b/codec.js
@@ -1,6 +1,9 @@
 export const CODEC_FUSIONS = {
   'H264+AAC': 'unlock',
-  'VP9+OGG': 'hallucination'
+  'VP9+OGG': 'hallucination',
+  'H264+VP9': 'switch',
+  'AAC+OGG': 'elevator',
+  'H264+OGG': 'hazard'
 };
 
 export class CodecItem extends Phaser.Physics.Arcade.Sprite {

--- a/main.js
+++ b/main.js
@@ -439,6 +439,12 @@ class TestScene extends Phaser.Scene {
         delay: 1000,
         callback: () => this.setMode(this.currentMode)
       });
+    } else if (result === 'switch') {
+      this.levelManager.activateSwitch(this.player);
+    } else if (result === 'elevator') {
+      this.levelManager.powerElevators();
+    } else if (result === 'hazard') {
+      this.levelManager.disableHazards();
     } else {
       this.cameras.main.shake(500, 0.01);
       this.player.setTint(0xff0000);

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ Primordial Slush.
   interact with environmental blocks and hazards.
 - Collectible codec items with compatibility rules.
 - Fuse codecs to unlock doors or trigger hallucinations.
+- Specific fusions now activate switches, power elevators, or disable hazards.
 - Puzzle combinations yield unique effects or spectacular failures.
 - Timecode HUD displaying playback integrity and energy levels.
 - Playback integrity decays when hit or during codec glitches.

--- a/src/level/manager.js
+++ b/src/level/manager.js
@@ -1,3 +1,6 @@
+import { PuzzleSwitch } from '../puzzles/switch.js';
+import { LockDoor } from '../puzzles/lockDoor.js';
+
 export class LevelManager {
   constructor(scene) {
     this.scene = scene;
@@ -18,18 +21,38 @@ export class LevelManager {
     });
     this.platforms = this.scene.physics.add.staticGroup();
     this.doors = this.scene.physics.add.staticGroup();
+    this.lockDoors = this.scene.physics.add.staticGroup();
+    this.switches = this.scene.physics.add.staticGroup();
+    this.hazards = this.scene.physics.add.staticGroup();
+    this.elevators = this.scene.physics.add.group();
   }
 
   start(startKey, player) {
     this.player = player;
     this.scene.physics.add.collider(player, this.platforms);
     this.scene.physics.add.collider(player, this.doors);
+    this.scene.physics.add.collider(player, this.lockDoors);
+    this.scene.physics.add.collider(player, this.elevators);
     this.scene.physics.add.overlap(
       player,
       this.doors,
       (pl, door) => {
         this.enterRoom(door.target, { x: door.startX, y: door.startY });
       }
+    );
+    this.scene.physics.add.overlap(
+      player,
+      this.lockDoors,
+      (pl, door) => {
+        if (!door.locked) {
+          this.enterRoom(door.target, { x: door.startX, y: door.startY });
+        }
+      }
+    );
+    this.scene.physics.add.overlap(
+      player,
+      this.hazards,
+      () => this.scene.takeDamage(10)
     );
     this.enterRoom(startKey, { x: player.x, y: player.y });
   }
@@ -39,6 +62,10 @@ export class LevelManager {
     if (!room) return;
     this.platforms.clear(true, true);
     this.doors.clear(true, true);
+    this.lockDoors.clear(true, true);
+    this.switches.clear(true, true);
+    this.hazards.clear(true, true);
+    this.elevators.clear(true, true);
 
     room.platforms.forEach(p => {
       const platform = this.scene.add
@@ -49,13 +76,57 @@ export class LevelManager {
     });
 
     room.doors.forEach(d => {
-      const door = this.scene.add.image(d.x, d.y, 'door').setOrigin(0.5, 1);
+      const door = this.scene.add
+        .image(d.x, d.y, 'door')
+        .setOrigin(0.5, 1);
       if (d.hidden) door.setAlpha(0);
       this.scene.physics.add.existing(door, true);
       door.target = d.target;
       door.startX = d.startX;
       door.startY = d.startY;
       this.doors.add(door);
+    });
+
+    const locks = [];
+    (room.locks || []).forEach(d => {
+      const door = new LockDoor(
+        this.scene,
+        d.x,
+        d.y,
+        d.target,
+        d.startX,
+        d.startY,
+        d.hidden
+      );
+      this.lockDoors.add(door);
+      locks.push(door);
+    });
+
+    (room.switches || []).forEach(s => {
+      const target = locks[s.targetLock];
+      const sw = new PuzzleSwitch(this.scene, s.x, s.y, target);
+      this.switches.add(sw);
+    });
+
+    (room.hazards || []).forEach(h => {
+      const hz = this.scene.add
+        .rectangle(h.x, h.y, h.width, h.height, 0xff0000)
+        .setOrigin(0.5, 0.5);
+      this.scene.physics.add.existing(hz, true);
+      this.hazards.add(hz);
+    });
+
+    (room.elevators || []).forEach(e => {
+      const el = this.scene.add
+        .rectangle(e.x, e.y, e.width, e.height, 0xaaaaaa)
+        .setOrigin(0.5, 0.5);
+      this.scene.physics.add.existing(el);
+      el.body.setAllowGravity(false);
+      el.body.setImmovable(true);
+      el.startY = e.y;
+      el.distance = e.distance || 100;
+      el.speed = e.speed || 50;
+      this.elevators.add(el);
     });
 
     const width = room.width || 800;
@@ -66,5 +137,32 @@ export class LevelManager {
     if (start) {
       this.player.setPosition(start.x, start.y);
     }
+  }
+
+  activateSwitch(player) {
+    this.scene.physics.overlap(
+      player,
+      this.switches,
+      (pl, sw) => sw.activate()
+    );
+  }
+
+  powerElevators() {
+    this.elevators.children.iterate(el => {
+      if (el.powered) return;
+      el.powered = true;
+      this.scene.tweens.add({
+        targets: el,
+        y: el.startY - el.distance,
+        duration: (el.distance / el.speed) * 1000,
+        yoyo: true,
+        repeat: -1,
+        ease: 'Linear'
+      });
+    });
+  }
+
+  disableHazards() {
+    this.hazards.clear(true, true);
   }
 }

--- a/src/level/rooms/room2.json
+++ b/src/level/rooms/room2.json
@@ -5,7 +5,19 @@
     { "x": 400, "y": 568, "width": 800, "height": 32 }
   ],
   "doors": [
-    { "x": 40, "y": 536, "target": "room1", "startX": 700, "startY": 450 },
-    { "x": 760, "y": 400, "target": "room3", "startX": 100, "startY": 450, "hidden": true }
+    { "x": 40, "y": 536, "target": "room1", "startX": 700, "startY": 450 }
+  ],
+  "locks": [
+    {
+      "x": 760,
+      "y": 400,
+      "target": "room3",
+      "startX": 100,
+      "startY": 450,
+      "hidden": true
+    }
+  ],
+  "switches": [
+    { "x": 400, "y": 536, "targetLock": 0 }
   ]
 }

--- a/src/level/rooms/room3.json
+++ b/src/level/rooms/room3.json
@@ -7,5 +7,18 @@
   ],
   "doors": [
     { "x": 40, "y": 536, "target": "room2", "startX": 700, "startY": 450 }
+  ],
+  "hazards": [
+    { "x": 400, "y": 548, "width": 200, "height": 20 }
+  ],
+  "elevators": [
+    {
+      "x": 400,
+      "y": 560,
+      "width": 40,
+      "height": 8,
+      "distance": 160,
+      "speed": 40
+    }
   ]
 }

--- a/src/puzzles/lockDoor.js
+++ b/src/puzzles/lockDoor.js
@@ -1,0 +1,20 @@
+export class LockDoor extends Phaser.Physics.Arcade.Sprite {
+  constructor(scene, x, y, target, startX, startY, hidden) {
+    super(scene, x, y, 'door');
+    scene.add.existing(this);
+    scene.physics.add.existing(this, true);
+    this.setOrigin(0.5, 1);
+    this.target = target;
+    this.startX = startX;
+    this.startY = startY;
+    this.locked = true;
+    if (hidden) this.setAlpha(0);
+    this.setTint(0xff0000);
+  }
+
+  unlock() {
+    this.locked = false;
+    this.clearTint();
+    this.setAlpha(1);
+  }
+}

--- a/src/puzzles/switch.js
+++ b/src/puzzles/switch.js
@@ -1,0 +1,19 @@
+export class PuzzleSwitch extends Phaser.GameObjects.Rectangle {
+  constructor(scene, x, y, target) {
+    super(scene, x, y, 20, 20, 0x999999);
+    scene.add.existing(this);
+    scene.physics.add.existing(this, true);
+    this.setOrigin(0.5, 0.5);
+    this.target = target;
+    this.activated = false;
+  }
+
+  activate() {
+    if (this.activated) return;
+    this.activated = true;
+    this.setFillStyle(0x00ff00);
+    if (this.target && this.target.unlock) {
+      this.target.unlock();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand CODEC_FUSIONS with switch, elevator, and hazard effects
- add PuzzleSwitch and LockDoor puzzle components
- update level manager and room data for codec-driven puzzles

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68957c8dbbb4832ca36ae3a89ea75fd6